### PR TITLE
Updated to latest upstream

### DIFF
--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -88,7 +88,7 @@
 #           untracked_vcs_color=BLUE      # Untracked files:
 #                  op_vcs_color=MAGENTA
 #            detached_vcs_color=RED
-#                 hex_vcs_color=dim
+#                 hex_vcs_color=BLACK	  # git version id:  bright black - should be displayed as gray
 
 
 # :vim:ft=sh ts=8 sw=8 et:

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -69,7 +69,7 @@
 
 #####  Per host color
 
-### Per host color.  If not set, color will be derived from name of host checksum).
+### Per host color.  If not set, color will be derived from hostname checksum).
 ### Variable name is uppercase-short-hostname with appended "_host_color"
 ### Example per-host-color config:  
 
@@ -88,7 +88,7 @@
 #           untracked_vcs_color=BLUE      # Untracked files:
 #                  op_vcs_color=MAGENTA
 #            detached_vcs_color=RED
-#                 hex_vcs_color=BLACK	  # git version id:  bright black - should be displayed as gray
+#                 hex_vcs_color=BLACK	  # git revision id:  bright black (makes gray)
 
 
 # :vim:ft=sh ts=8 sw=8 et:

--- a/git-prompt.conf
+++ b/git-prompt.conf
@@ -19,6 +19,7 @@
 # svn_module=off
 # hg_module=on
 # vim_module=on
+# virtualenv_module=on
 
 
 ###########################################################   DEFAULT OBJECTS
@@ -53,6 +54,7 @@
 #        if [[ -n "$cols" && $cols -ge 8 ]];  then                              #  if terminal supports colors
         #       dir_color=CYAN
         #       rc_color=red
+        #       virtualenv_color=green
         #       user_id_color=blue
         #       root_id_color=magenta
 # else                                          #  B/W terminal

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -1,3 +1,14 @@
+		# cannot be started directly; must be called from `.` or `source` builtin
+		if [[ $0 != *bash ]]; then
+			cat <<-"EOF" >&2
+				This script *MUST* be called using the bash builtin `source`,
+				or its shorter counterpart, `.`, in order to function properly.
+				It cannot be started directly.
+				
+			EOF
+			exit
+		fi
+		
         # don't set prompt if this is not interactive shell
         [[ $- != *i* ]]  &&  return
 
@@ -712,7 +723,7 @@ prompt_command_function() {
 		parse_virtualenv_status
         parse_vcs_status
         [[ $rvm_module = "on" ]] && type rvm >&/dev/null && parse_rvm_status
-        [[ $clock_module = "on" ]] && local clock="$clock_color$(date +$clock_format) "
+        [[ $clock_module = "on" ]] && local clock="$clock_color$(date "+$clock_format") "
 
 
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -393,8 +393,13 @@ parse_hg_status() {
 
         branch=`hg branch 2> /dev/null`
 
+        [[ -f $hg_root/.hg/bookmarks.current ]] && bookmark=`cat "$hg_root/.hg/bookmarks.current"`
+
         [[ -z $modified ]]   &&   [[ -z $untracked ]]   &&   [[ -z $added ]]   &&   clean=clean
         vcs_info=${branch/default/D}
+        if [[ "$bookmark" ]] ;  then
+                vcs_info+=/$bookmark
+        fi
  }
 
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -375,8 +375,7 @@ parse_svn_status() {
 parse_hg_status() {
 
         # ☿
-
-        [[  -d ./.hg/ ]]  ||  return  1
+        hg_root=`hg root 2>/dev/null` || return 1
 
         vcs=hg
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -443,13 +443,23 @@ parse_git_status() {
         )"
 
 	# porcelain file list
-                                                # TODO:  sed-less -- http://tldp.org/LDP/abs/html/arrays.html  -- Example 27-5
+                                        # TODO:  sed-less -- http://tldp.org/LDP/abs/html/arrays.html  -- Example 27-5
+
+                                        # git bug:  (was reported to git@vger.kernel.org )
+                                        # echo 1 > "with space"
+                                        # git status --porcelain
+                                        # ?? with space                   <------------ NO QOUTES
+                                        # git add with\ space
+                                        # git status --porcelain
+                                        # A  "with space"                 <------------- WITH QOUTES
+
         eval " $(
                 git status --porcelain 2>/dev/null |
                     sed -n '
                         s/^[MARC]. \(.*\)/      added=added;            [[ \" ${added_files[*]} \" =~  \1  ]]    || added_files[${#added_files[@]}]=\1/p
                         s/^.[MAU] \(.*\)/	modified=modified;      [[ \" ${modified_files[*]} \" =~  \1 ]]  || modified_files[${#modified_files[@]}]=\1/p
-                        s/^?? \(.*\)/           untracked=untracked;    [[ \" ${untracked_files[*]} \" =~ \1 ]]  || untracked_files[${#untracked_files[@]}]=\1/p
+                        s/^?? \([a-zA-Z_.=:]*\)$/           untracked=untracked;    [[ \" ${untracked_files[*]} \" =~ \" \1 \" ]]  || untracked_files[${#untracked_files[@]}]=\"\1\"/p
+                        s/^?? \(.*\)$/           untracked=untracked;    [[ \" ${untracked_files[*]} \" =~ \" \1 \" ]]  || untracked_files[${#untracked_files[@]}]=\"\1\"/p
                     '
         )"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -201,7 +201,7 @@ cwd_truncate() {
 
 		# trunc middle if over limit
                 if   [[ ${#path_middle}   -gt   $(( $cwd_middle_max + ${#elipses_marker} + 5 )) ]];   then
-			
+
 			# truncate
 			middle_tail=${path_middle:${#path_middle}-${cwd_middle_max}}
 
@@ -225,7 +225,7 @@ set_shell_label() {
         xterm_label() {
                 local args="$*"
                 echo  -n "]2;${args:0:200}" ;    # FIXME: replace hardcodes with terminfo codes
-        }   
+        }
 
         screen_label() {
                 # FIXME: run this only if screen is in xterm (how to test for this?)
@@ -301,7 +301,7 @@ set_shell_label() {
         if [[ $short_hostname = "on" ]]; then
 			if [[ "$(uname)" =~ "CYGWIN" ]]; then
 				host=`hostname`
-			else 
+			else
 				host=`hostname -s`
 			fi
         fi
@@ -517,7 +517,7 @@ parse_git_status() {
 
         ### compose vcs_info
 
-        if [[ $init ]];  then 
+        if [[ $init ]];  then
                 vcs_info=${white}init
 
         else
@@ -578,7 +578,7 @@ parse_vcs_status() {
                 if [[ $vim_glob ]];  then
                     set $vim_glob
                     #vim_file=${vim_glob#.}
-                    if [[ $# > 1 ]] ; then 
+                    if [[ $# > 1 ]] ; then
                             vim_files="*"
                     else
                             vim_file=${1#.}

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -149,7 +149,6 @@
         fi
 
         ####################################################################  MARKERS
-        screen_marker="sCRn"
         if [[ $LC_CTYPE =~ "UTF" && $TERM != "linux" ]];  then
                 elipses_marker="…"
         else
@@ -228,7 +227,7 @@ set_shell_label() {
 
         screen_label() {
                 # FIXME: run this only if screen is in xterm (how to test for this?)
-                xterm_label  "$screen_marker  $plain_who_where $@"
+                xterm_label  "$plain_who_where $@"
 
                 # FIXME $STY not inherited though "su -"
                 [ "$STY" ] && screen -S $STY -X title "$*"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -306,7 +306,7 @@ set_shell_label() {
 			fi
         fi
         host=${host#$default_host}
-        uphost=`echo ${host} | tr a-z A-Z`
+        uphost=`echo ${host} | tr a-z-. A-Z_`
         if [[ $upcase_hostname = "on" ]]; then
                 host=${uphost}
         fi

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -222,7 +222,10 @@ cwd_truncate() {
 
 set_shell_label() {
 
-        xterm_label() { echo  -n "]2;${@}" ; }   # FIXME: replace hardcodes with terminfo codes
+        xterm_label() {
+                local args="$*"
+                echo  -n "]2;${args:0:200}" ;    # FIXME: replace hardcodes with terminfo codes
+        }   
 
         screen_label() {
                 # FIXME: run this only if screen is in xterm (how to test for this?)

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -465,7 +465,7 @@ parse_git_status() {
                     '
         )"
 
-        if  ! grep -q "^ref:" $git_dir/HEAD  2>/dev/null;   then
+        if  ! grep -q "^ref:" "$git_dir/HEAD"  2>/dev/null;   then
                 detached=detached
         fi
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -422,7 +422,6 @@ parse_git_status() {
         vcs=git
 
         ##########################################################   GIT STATUS
-	file_regex='\([^/ ]*\/\{0,1\}\).*'
 	added_files=()
 	modified_files=()
 	untracked_files=()
@@ -509,7 +508,7 @@ parse_git_status() {
         fi
 
         #### branch
-        branch=${branch/master/M}
+        branch=${branch/#master/M}
 
                         # another method of above:
                         # branch=$(git symbolic-ref -q HEAD || { echo -n "detached:" ; git name-rev --name-only HEAD 2>/dev/null; } )

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -524,8 +524,13 @@ parse_git_status() {
                         fi
                 fi
                 if [[ $(git branch -a | grep $remote) != "" ]]; then
-                        if [[ -f $git_dir/FETCH_HEAD && $(git log --oneline HEAD..$remote/master) != "" ]]; then
-                                remotes+=" "$remote:$(git log --oneline HEAD..$remote/master | wc -l) 
+                        nRemoteCommit=$(git log --oneline HEAD..$remote/master | wc -l)
+                        if [[ -f $git_dir/FETCH_HEAD && $nRemoteCommit != "0" ]]; then
+                                if [[ $remote == "origin" ]]; then
+                                        remotes+=" o:"$nRemoteCommit 
+                                else
+                                        remotes+=" "$remote:$nRemoteCommit
+                                fi
                         fi
                 else
                         git fetch $remote >& /dev/null &

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -23,6 +23,7 @@
         svn_module=${svn_module:-off}
         hg_module=${hg_module:-on}
         vim_module=${vim_module:-on}
+        virtualenv_module=${virtualenv_module:-on}
         error_bell=${error_bell:-off}
         cwd_cmd=${cwd_cmd:-\\w}
 
@@ -32,6 +33,7 @@
         if [[ -n "$cols" && $cols -ge 8 ]];  then       #  if terminal supports colors
                 dir_color=${dir_color:-CYAN}
                 rc_color=${rc_color:-red}
+                virtualenv_color=${virtualenv_color:-green}
                 user_id_color=${user_id_color:-blue}
                 root_id_color=${root_id_color:-magenta}
         else                                            #  only B/W
@@ -284,6 +286,7 @@ set_shell_label() {
 
         dir_color=${!dir_color}
         rc_color=${!rc_color}
+        virtualenv_color=${!virtualenv_color}
         user_id_color=${!user_id_color}
         root_id_color=${!root_id_color}
 
@@ -632,6 +635,17 @@ parse_vcs_status() {
         #tail_local="${tail_local+$vcs_color $tail_local}${dir_color}"
  }
 
+parse_virtualenv_status() {
+    unset virtualenv
+
+    [[ $virtualenv_module = "on" ]] || return 1
+
+    if [[ -n "$VIRTUAL_ENV" ]] ; then
+	virtualenv=`basename $VIRTUAL_ENV`
+	rc="$rc $virtualenv_color<$virtualenv> "
+    fi
+ }
+
 disable_set_shell_label() {
         trap - DEBUG  >& /dev/null
  }
@@ -682,6 +696,7 @@ prompt_command_function() {
         cwd=${PWD/$HOME/\~}                     # substitute  "~"
         set_shell_label "${cwd##[/~]*/}/"       # default label - path last dir
 
+	parse_virtualenv_status
         parse_vcs_status
 
         # autojump

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -275,7 +275,7 @@ set_shell_label() {
 
         # we don't need tty name under X11
         case $TERM in
-                xterm* | rxvt* | gnome-terminal | konsole | eterm | wterm | cygwin)  unset tty ;;
+                xterm* | rxvt* | gnome-terminal | konsole | eterm* | wterm | cygwin)  unset tty ;;
                 *);;
         esac
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -243,7 +243,7 @@ set_shell_label() {
                                 screen_label "$*"
                                 ;;
 
-                        xterm* | rxvt* | gnome-terminal | konsole | eterm | wterm )
+                        xterm* | rxvt* | gnome-* | konsole | eterm | wterm )
                                 # is there a capability which we can to test
                                 # for "set term title-bar" and its escapes?
                                 xterm_label  "$plain_who_where $@"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -1,4 +1,3 @@
-
         # don't set prompt if this is not interactive shell
         [[ $- != *i* ]]  &&  return
 
@@ -309,7 +308,7 @@ set_shell_label() {
         host_color=${uphost}_host_color
         host_color=${!host_color}
         if [[ -z $host_color && -x /usr/bin/cksum ]] ;  then
-                cksum_color_no=`echo $uphost | cksum  | awk '{print $1%7}'`
+                cksum_color_no=`echo $uphost | cksum  | awk '{print $1%6}'`
                 color_index=(green yellow blue magenta cyan white)              # FIXME:  bw,  color-256
                 host_color=${color_index[cksum_color_no]}
         fi

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -9,7 +9,6 @@
         unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
         unset modified_vcs_color added_vcs_color addmoded_vcs_color untracked_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
         unset rawhex_len
-        unset remotes
 
         conf=git-prompt.conf;                   [[ -r $conf ]]  && . $conf
         conf=/etc/git-prompt.conf;              [[ -r $conf ]]  && . $conf
@@ -583,6 +582,7 @@ parse_vcs_status() {
         unset   vcs vcs_info
         unset   status modified untracked added init detached
         unset   file_list modified_files untracked_files added_files
+        unset   remotes
 
         [[ $vcs_ignore_dir_list =~ $PWD ]] && return
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -9,6 +9,7 @@
         unset dir_color rc_color user_id_color root_id_color init_vcs_color clean_vcs_color
         unset modified_vcs_color added_vcs_color addmoded_vcs_color untracked_vcs_color op_vcs_color detached_vcs_color hex_vcs_color
         unset rawhex_len
+        unset remotes
 
         conf=git-prompt.conf;                   [[ -r $conf ]]  && . $conf
         conf=/etc/git-prompt.conf;              [[ -r $conf ]]  && . $conf

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -644,6 +644,9 @@ enable_set_shell_label() {
 	     set_shell_label $BASH_COMMAND' DEBUG  >& /dev/null
  }
 
+declare -ft disable_set_shell_label
+declare -ft enable_set_shell_label
+
 # autojump (see http://wiki.github.com/joelthelion/autojump)
 
 # TODO reverse the line order of a file

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -414,7 +414,7 @@ parse_git_status() {
 	added_files=()
 	modified_files=()
 	untracked_files=()
-        freshness="$dim="
+        freshness="$dim"
         unset branch status modified added clean init added mixed untracked op detached
 
 	# quoting hell
@@ -512,7 +512,7 @@ parse_git_status() {
         if  [[ $rawhex_len -gt 0 ]] ;  then
                 rawhex=`git rev-parse HEAD 2>/dev/null`
                 rawhex=${rawhex/HEAD/}
-                rawhex="$hex_vcs_color${rawhex:0:$rawhex_len}"
+                rawhex="=$hex_vcs_color${rawhex:0:$rawhex_len}"
         else
                 rawhex=""
         fi

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -428,9 +428,9 @@ parse_git_status() {
                         s/^nothing to commi.*/clean=clean/p
                         s/^# Initial commi.*/init=init/p
 
-                        s/^# Your branch is ahead of .[/[:alnum:]]\+. by [[:digit:]]\+ commit.*/freshness=${WHITE}↑/p
-                        s/^# Your branch is behind .[/[:alnum:]]\+. by [[:digit:]]\+ commit.*/freshness=${YELLOW}↓/p
-                        s/^# Your branch and .[/[:alnum:]]\+. have diverged.*/freshness=${YELLOW}↕/p
+                        s/^# Your branch is ahead of \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${WHITE}↑/p
+                        s/^# Your branch is behind \(.\).\+\1 by [[:digit:]]\+ commit.*/freshness=${YELLOW}↓/p
+                        s/^# Your branch and \(.\).\+\1 have diverged.*/freshness=${YELLOW}↕/p
 
                         /^# Changes to be committed:/,/^# [A-Z]/ {
                             s/^# Changes to be committed:/added=added;/p

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -515,7 +515,7 @@ parse_git_status() {
                 if [[ ! -e $git_dir/FETCH_HEAD ]]; then
                         git fetch $remote >& /dev/null &
                 else
-                        fetchDate=$(date --utc --reference=.git/FETCH_HEAD +%s)
+                        fetchDate=$(date --utc --reference=$git_dir/FETCH_HEAD +%s)
                         now=$(date --utc +%s)
                         delta=$(( $now - $fetchDate ))
                         # if last update to .git/FETCH_HEAD file 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -506,35 +506,7 @@ parse_git_status() {
                 #    branch="$(git describe --exact-match HEAD 2>/dev/null)" || \
                 #    branch="$(cut -c1-7 "$git_dir/HEAD")..."
         fi
-		if [[ $branch == "master" ]]; then
-			# Only work with master branch 
-	        # TODO : make this a module on/off
-	        # hourly checks new commits in remotes
-	        fetchUpdate=3600 
-	        remotes=()
-	        for remote in $(git remote)
-	        do
-	                if [[ ! -e $git_dir/FETCH_HEAD ]]; then
-	                        git fetch $remote >& /dev/null &
-	                else
-	                        fetchDate=$(date --utc --reference=$git_dir/FETCH_HEAD +%s)
-	                        now=$(date --utc +%s)
-	                        delta=$(( $now - $fetchDate ))
-	                        # if last update to .git/FETCH_HEAD file 
-	                        if [[ $delta -gt $fetchUpdate  ]]; then
-	                                git fetch $remote >& /dev/null &
-	                        fi
-	                fi
-	                if [[ $(git branch -a | grep $remote) != "" ]]; then
-	                        nRemoteCommit=$(git log --oneline HEAD..$remote/master | wc -l)
-	                        if [[ -f $git_dir/FETCH_HEAD && $nRemoteCommit != "0" ]]; then
-	                                remotes+=" "${remote/origin/o}:$nRemoteCommit
-	                        fi
-	                else
-	                        git fetch $remote >& /dev/null &
-	                fi
-	        done
-		fi
+
 
         ####  GET GIT HEX-REVISION
         if  [[ $rawhex_len -gt 0 ]] ;  then
@@ -581,7 +553,6 @@ parse_vcs_status() {
         unset   vcs vcs_info
         unset   status modified untracked added init detached
         unset   file_list modified_files untracked_files added_files
-        unset   remotes
 
         [[ $vcs_ignore_dir_list =~ $PWD ]] && return
 
@@ -650,7 +621,7 @@ parse_vcs_status() {
         fi
 
 
-        head_local="$vcs_color(${vcs_info}$vcs_color${file_list}$vcs_color$remotes)"
+        head_local="$vcs_color(${vcs_info}$vcs_color${file_list}$vcs_color)"
 
         ### fringes
         head_local="${head_local+$vcs_color$head_local }"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -151,7 +151,7 @@
         fi
 
         ####################################################################  MARKERS
-        if [[ $LC_CTYPE =~ "UTF" && $TERM != "linux" ]];  then
+        if [[ "$LC_CTYPE $LC_ALL" =~ "UTF" && $TERM != "linux" ]];  then
                 elipses_marker="…"
         else
                 elipses_marker="..."

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -444,9 +444,9 @@ parse_git_status() {
         eval " $(
                 git status --porcelain 2>/dev/null |
                     sed -n '
-                        s/^[MARC]. \(.*\)/      added=added;            [[ \" ${added_files[*]} \" =~ \" \1 \" ]]       || added_files[${#added_files[@]}]=\"\1\"/p
-                        s/^.[MAU] \(.*\)/	modified=modified;      [[ \" ${modified_files[*]} \" =~ \" \1 \" ]]    || modified_files[${#modified_files[@]}]=\"\1\"/p
-                        s/^?? \(.*\)/           untracked=untracked;    [[ \" ${untracked_files[*]} \" =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\"/p
+                        s/^[MARC]. \(.*\)/      added=added;            [[ \" ${added_files[*]} \" =~  \1  ]]    || added_files[${#added_files[@]}]=\1/p
+                        s/^.[MAU] \(.*\)/	modified=modified;      [[ \" ${modified_files[*]} \" =~  \1 ]]  || modified_files[${#modified_files[@]}]=\1/p
+                        s/^?? \(.*\)/           untracked=untracked;    [[ \" ${untracked_files[*]} \" =~ \1 ]]  || untracked_files[${#untracked_files[@]}]=\1/p
                     '
         )"
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -506,7 +506,31 @@ parse_git_status() {
                 #    branch="$(git describe --exact-match HEAD 2>/dev/null)" || \
                 #    branch="$(cut -c1-7 "$git_dir/HEAD")..."
         fi
-
+        # TODO : make this a module on/off
+        # hourly checks new commits in remotes
+        fetchUpdate=3600 
+        remotes=()
+        for remote in $(git remote)
+        do
+                if [[ ! -e $git_dir/FETCH_HEAD ]]; then
+                        git fetch $remote >& /dev/null &
+                else
+                        fetchDate=$(date --utc --reference=.git/FETCH_HEAD +%s)
+                        now=$(date --utc +%s)
+                        delta=$(( $now - $fetchDate ))
+                        # if last update to .git/FETCH_HEAD file 
+                        if [[ $delta -gt $fetchUpdate  ]]; then
+                                git fetch $remote >& /dev/null &
+                        fi
+                fi
+                if [[ $(git branch -a | grep $remote) != "" ]]; then
+                        if [[ -f $git_dir/FETCH_HEAD && $(git log --oneline HEAD..$remote/master) != "" ]]; then
+                                remotes+=" "$remote:$(git log --oneline HEAD..$remote/master | wc -l) 
+                        fi
+                else
+                        git fetch $remote >& /dev/null &
+                fi
+        done
 
         ####  GET GIT HEX-REVISION
         if  [[ $rawhex_len -gt 0 ]] ;  then
@@ -621,7 +645,7 @@ parse_vcs_status() {
         fi
 
 
-        head_local="$vcs_color(${vcs_info}$vcs_color${file_list}$vcs_color)"
+        head_local="$vcs_color(${vcs_info}$vcs_color${file_list}$vcs_color$remotes)"
 
         ### fringes
         head_local="${head_local+$vcs_color$head_local }"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -455,12 +455,14 @@ parse_git_status() {
 
         eval " $(
                 git status --porcelain 2>/dev/null |
-                    sed -n '
-                        s/^[MARC]. \(.*\)/      added=added;            [[ \" ${added_files[*]} \" =~  \1  ]]    || added_files[${#added_files[@]}]=\1/p
-                        s/^.[MAU] \(.*\)/	modified=modified;      [[ \" ${modified_files[*]} \" =~  \1 ]]  || modified_files[${#modified_files[@]}]=\1/p
-                        s/^?? \([a-zA-Z_.=:]*\)$/           untracked=untracked;    [[ \" ${untracked_files[*]} \" =~ \" \1 \" ]]  || untracked_files[${#untracked_files[@]}]=\"\1\"/p
-                        s/^?? \(.*\)$/           untracked=untracked;    [[ \" ${untracked_files[*]} \" =~ \" \1 \" ]]  || untracked_files[${#untracked_files[@]}]=\"\1\"/p
-                    '
+                        sed -n '
+                                s,^[MARC]. \([^\"][^/]*/\?\).*,         added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
+                                s,^[MARC]. \"\([^/]\+/\?\).*\"$,        added=added;           [[ \" ${added_files[@]} \"      =~ \" \1 \" ]]   || added_files[${#added_files[@]}]=\"\1\",p
+                                s,^.[MAU] \([^\"][^/]*/\?\).*,          modified=modified;     [[ \" ${modified_files[@]} \"   =~ \" \1 \" ]]   || modified_files[${#modified_files[@]}]=\"\1\",p
+                                s,^.[MAU] \"\([^/]\+/\?\).*\"$,         modified=modified;     [[ \" ${modified_files[@]} \"   =~ \" \1 \" ]]   || modified_files[${#modified_files[@]}]=\"\1\",p
+                                s,^?? \([^\"][^/]*/\?\).*,              untracked=untracked;   [[ \" ${untracked_files[@]} \"  =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\",p
+                                s,^?? \"\([^/]\+/\?\).*\"$,             untracked=untracked;   [[ \" ${untracked_files[@]} \"  =~ \" \1 \" ]]   || untracked_files[${#untracked_files[@]}]=\"\1\",p
+                        '   # |tee /dev/tty
         )"
 
         if  ! grep -q "^ref:" "$git_dir/HEAD"  2>/dev/null;   then

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -506,32 +506,35 @@ parse_git_status() {
                 #    branch="$(git describe --exact-match HEAD 2>/dev/null)" || \
                 #    branch="$(cut -c1-7 "$git_dir/HEAD")..."
         fi
-        # TODO : make this a module on/off
-        # hourly checks new commits in remotes
-        fetchUpdate=3600 
-        remotes=()
-        for remote in $(git remote)
-        do
-                if [[ ! -e $git_dir/FETCH_HEAD ]]; then
-                        git fetch $remote >& /dev/null &
-                else
-                        fetchDate=$(date --utc --reference=$git_dir/FETCH_HEAD +%s)
-                        now=$(date --utc +%s)
-                        delta=$(( $now - $fetchDate ))
-                        # if last update to .git/FETCH_HEAD file 
-                        if [[ $delta -gt $fetchUpdate  ]]; then
-                                git fetch $remote >& /dev/null &
-                        fi
-                fi
-                if [[ $(git branch -a | grep $remote) != "" ]]; then
-                        nRemoteCommit=$(git log --oneline HEAD..$remote/master | wc -l)
-                        if [[ -f $git_dir/FETCH_HEAD && $nRemoteCommit != "0" ]]; then
-                                remotes+=" "${remote/origin/o}:$nRemoteCommit
-                        fi
-                else
-                        git fetch $remote >& /dev/null &
-                fi
-        done
+		if [[ $branch == "master" ]]; then
+			# Only work with master branch 
+	        # TODO : make this a module on/off
+	        # hourly checks new commits in remotes
+	        fetchUpdate=3600 
+	        remotes=()
+	        for remote in $(git remote)
+	        do
+	                if [[ ! -e $git_dir/FETCH_HEAD ]]; then
+	                        git fetch $remote >& /dev/null &
+	                else
+	                        fetchDate=$(date --utc --reference=$git_dir/FETCH_HEAD +%s)
+	                        now=$(date --utc +%s)
+	                        delta=$(( $now - $fetchDate ))
+	                        # if last update to .git/FETCH_HEAD file 
+	                        if [[ $delta -gt $fetchUpdate  ]]; then
+	                                git fetch $remote >& /dev/null &
+	                        fi
+	                fi
+	                if [[ $(git branch -a | grep $remote) != "" ]]; then
+	                        nRemoteCommit=$(git log --oneline HEAD..$remote/master | wc -l)
+	                        if [[ -f $git_dir/FETCH_HEAD && $nRemoteCommit != "0" ]]; then
+	                                remotes+=" "${remote/origin/o}:$nRemoteCommit
+	                        fi
+	                else
+	                        git fetch $remote >& /dev/null &
+	                fi
+	        done
+		fi
 
         ####  GET GIT HEX-REVISION
         if  [[ $rawhex_len -gt 0 ]] ;  then

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -526,11 +526,7 @@ parse_git_status() {
                 if [[ $(git branch -a | grep $remote) != "" ]]; then
                         nRemoteCommit=$(git log --oneline HEAD..$remote/master | wc -l)
                         if [[ -f $git_dir/FETCH_HEAD && $nRemoteCommit != "0" ]]; then
-                                if [[ $remote == "origin" ]]; then
-                                        remotes+=" o:"$nRemoteCommit 
-                                else
-                                        remotes+=" "$remote:$nRemoteCommit
-                                fi
+                                remotes+=" "${remote/origin/o}:$nRemoteCommit
                         fi
                 else
                         git fetch $remote >& /dev/null &

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -425,7 +425,8 @@ parse_git_status() {
 	added_files=()
 	modified_files=()
 	untracked_files=()
-        freshness="$dim"
+        [[ $rawhex_len -gt 0 ]]  && freshness="$dim="
+
         unset branch status modified added clean init added mixed untracked op detached
 
 	# info not in porcelain status
@@ -502,7 +503,7 @@ parse_git_status() {
         if  [[ $rawhex_len -gt 0 ]] ;  then
                 rawhex=`git rev-parse HEAD 2>/dev/null`
                 rawhex=${rawhex/HEAD/}
-                rawhex="=$hex_vcs_color${rawhex:0:$rawhex_len}"
+                rawhex="$hex_vcs_color${rawhex:0:$rawhex_len}"
         else
                 rawhex=""
         fi

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -317,7 +317,6 @@ set_shell_label() {
         # we might already have short host name
         host=${host%.$default_domain}
 
-
 #################################################################### WHO_WHERE
         #  [[user@]host[-tty]]
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -298,7 +298,11 @@ set_shell_label() {
 
         host=${HOSTNAME}
         if [[ $short_hostname = "on" ]]; then
-            host=`hostname -s`
+			if [[ "$(uname)" =~ "CYGWIN" ]]; then
+				host=`hostname`
+			else 
+				host=`hostname -s`
+			fi
         fi
         host=${host#$default_host}
         uphost=`echo ${host} | tr a-z A-Z`

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -54,11 +54,7 @@
                    op_vcs_color=${op_vcs_color:-MAGENTA}
              detached_vcs_color=${detached_vcs_color:-RED}
 
-             if [[ $OSTYPE == "linux-gnu" ]] ;  then                # no linux OSs do not support extra colors
-                  hex_vcs_color=${hex_vcs_color:-dim}
-             else
-                  hex_vcs_color=${hex_vcs_color:-colors_reset}
-             fi
+                  hex_vcs_color=${hex_vcs_color:-BLACK}         # gray
 
 
         max_file_list_length=${max_file_list_length:-100}

--- a/index.txt
+++ b/index.txt
@@ -108,7 +108,15 @@ Some distros also have `/etc/bashrc` or `/etc/bash/bashrc` with distro default
 prompt.
 
 
-== Config 
+//////////////////////////////
+== Git config 
+
+git config [--global] core.quotepath off
+git config [--global] --unset svn.pathnameencoding
+git config [--global] --unset i18n.logoutputencoding
+///////////////////////////////////
+
+== Git-print config 
 [[config]]
 
 Is optional.  If config file is not found then git-prompt uses defaults. 

--- a/index.txt
+++ b/index.txt
@@ -108,15 +108,19 @@ Some distros also have `/etc/bashrc` or `/etc/bash/bashrc` with distro default
 prompt.
 
 
-//////////////////////////////
-== Git config 
 
+== GIT config 
+
+GIT-PROMPT requires following GIT's option to be set:
+
+-------------------------
 git config [--global] core.quotepath off
 git config [--global] --unset svn.pathnameencoding
 git config [--global] --unset i18n.logoutputencoding
-///////////////////////////////////
+-----------------------------
 
-== Git-print config 
+
+== GIT-PROMPT config 
 [[config]]
 
 Is optional.  If config file is not found then git-prompt uses defaults. 

--- a/index.txt
+++ b/index.txt
@@ -2,6 +2,9 @@
 
 = GIT Prompt
 
+* Repo: httpx://github.com/lvv/scc[GitHub],  httpx://bitbucket.org/lvv/scc[BitBucket] +
+* License:  httpx://www.gnu.org/licenses/gpl-3.0.html[GPL3]
+
 :v-p:		http://volnitsky.com/project
 :compact-option: compact
 
@@ -158,6 +161,9 @@ dependencies are standard unix utils.
 
 == Todo
 
+* httpx://jonisalonen.com/2012/your-bash-prompt-needs-this/[]
+* httpx://tldp.org/HOWTO/Bash-Prompt-HOWTO/x810.html[Beep after long running command]
+* httpx://briancarper.net/blog/248/[Sync bash history]
 * VIM module needs to be moved out of GIT module
 
 include::../volnitsky.com/project/howto-submit-patch.txt[]


### PR DESCRIPTION
Looking through the various forks, yours seemed the most useful to me, so I updated it to the latest version of the upstream code, opting for the "official" virtual env code.  I also modified the `date` command used in the clock module to allow spaces in the format string, as I tend to like the current date visible as well.  Finally, I added a check at the beginning of the script to remind users that it must be run using `source` or `.` rather than directly.  That last bit I'll probably propose upstream as well, since it really ought to have been there from version zero.

Thought you might enjoy the tweaks!
